### PR TITLE
Improve RDF import/export performance and add RDF benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +447,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -584,6 +623,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1080,6 +1155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,10 +1468,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1666,7 +1767,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -1696,6 +1797,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -1888,6 +1995,34 @@ checksum = "3daf8e3d4b712abe1d690838f6e29fb76b76ea19589c4afa39ec30e12f62af71"
 dependencies = [
  "array-init-cursor",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -2879,6 +3014,7 @@ version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",
+ "criterion",
  "dirs",
  "hex",
  "log",
@@ -3444,6 +3580,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,15 @@ name = "rocraters"
 path = "src/lib.rs"
 doctest = false
 
+[[bench]]
+name = "create_and_write"
+harness = false
+
+[[bench]]
+name = "rdf_perf"
+harness = false
+required-features = ["rdf"]
+
 [features]
 parquet = ["dep:polars"]
 rdf = ["dep:oxrdf", "dep:oxrdfio"]
@@ -81,3 +90,4 @@ oxrdfio = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile = "3.24"
 mockito = "1.7.1"
+criterion = "0.5"

--- a/benches/create_and_write.rs
+++ b/benches/create_and_write.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use rocraters::ro_crate::constraints::*;
 use rocraters::ro_crate::contextual_entity::ContextualEntity;

--- a/benches/rdf_perf.rs
+++ b/benches/rdf_perf.rs
@@ -1,0 +1,228 @@
+use std::collections::HashMap;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use rocraters::ro_crate::constraints::{DataType, EntityValue, Id, License};
+use rocraters::ro_crate::context::RoCrateContext;
+use rocraters::ro_crate::contextual_entity::ContextualEntity;
+use rocraters::ro_crate::data_entity::DataEntity;
+use rocraters::ro_crate::graph_vector::GraphVector;
+use rocraters::ro_crate::metadata_descriptor::MetadataDescriptor;
+use rocraters::ro_crate::rdf::{
+    ContextResolverBuilder, ConversionOptions, RdfFormat, RdfGraph, rdf_graph_to_rocrate,
+    rdf_to_rocrate, rocrate_to_rdf_with_options,
+};
+use rocraters::ro_crate::rocrate::RoCrate;
+use rocraters::ro_crate::root::RootDataEntity;
+
+const BASE_IRI: &str = "https://example.org/bench/";
+const ROCRATE_CONTEXT_IRI: &str = "https://w3id.org/ro/crate/1.2/context";
+
+struct BenchmarkInput {
+    entities: usize,
+    triples: usize,
+    rocrate: RoCrate,
+    rdf_graph: RdfGraph,
+    turtle: String,
+}
+
+fn benchmark_input(data_entities: usize) -> BenchmarkInput {
+    let rocrate = synthetic_rocrate(data_entities);
+    let rdf_graph = rocrate_to_rdf_with_options(
+        &rocrate,
+        ContextResolverBuilder::default(),
+        ConversionOptions::with_base(BASE_IRI),
+    )
+    .expect("serialize benchmark fixture");
+    let turtle = rdf_graph
+        .to_string(RdfFormat::Turtle)
+        .expect("serialize turtle benchmark fixture");
+
+    BenchmarkInput {
+        entities: rocrate.graph.len(),
+        triples: rdf_graph.len(),
+        rocrate,
+        rdf_graph,
+        turtle,
+    }
+}
+
+fn synthetic_rocrate(data_entities: usize) -> RoCrate {
+    let author_count = data_entities.div_ceil(16).clamp(4, 64);
+    let authors_per_file = 3usize.min(author_count.max(1));
+
+    let mut graph = Vec::with_capacity(data_entities + author_count + 2);
+    graph.push(GraphVector::MetadataDescriptor(MetadataDescriptor {
+        id: "ro-crate-metadata.json".to_string(),
+        type_: DataType::Term("CreativeWork".to_string()),
+        conforms_to: Id::Id(ROCRATE_CONTEXT_IRI.to_string()),
+        about: Id::Id("./".to_string()),
+        dynamic_entity: None,
+    }));
+
+    let data_ids: Vec<String> = (0..data_entities)
+        .map(|index| format!("./data/file-{index:05}.csv"))
+        .collect();
+
+    let mut root_dynamic = HashMap::with_capacity(2);
+    root_dynamic.insert(
+        "hasPart".to_string(),
+        EntityValue::EntityId(Id::IdArray(data_ids.clone())),
+    );
+    root_dynamic.insert(
+        "creator".to_string(),
+        EntityValue::EntityId(Id::IdArray(
+            (0..author_count)
+                .map(|index| format!("#person-{index:03}"))
+                .collect(),
+        )),
+    );
+
+    graph.push(GraphVector::RootDataEntity(RootDataEntity {
+        id: "./".to_string(),
+        type_: DataType::Term("Dataset".to_string()),
+        name: format!("Synthetic RDF benchmark crate ({data_entities} files)"),
+        description: "Synthetic benchmark for RO-Crate RDF serialization and deserialization"
+            .to_string(),
+        date_published: "2026-03-25".to_string(),
+        license: License::Id(Id::Id("https://spdx.org/licenses/Apache-2.0".to_string())),
+        dynamic_entity: Some(root_dynamic),
+    }));
+
+    for index in 0..author_count {
+        let mut dynamic_entity = HashMap::with_capacity(3);
+        dynamic_entity.insert(
+            "name".to_string(),
+            EntityValue::EntityString(format!("Researcher {index:03}")),
+        );
+        dynamic_entity.insert(
+            "affiliation".to_string(),
+            EntityValue::EntityString(format!("Benchmark Lab {}", index % 8)),
+        );
+        dynamic_entity.insert(
+            "email".to_string(),
+            EntityValue::EntityString(format!("researcher{index:03}@example.org")),
+        );
+
+        graph.push(GraphVector::ContextualEntity(ContextualEntity {
+            id: format!("#person-{index:03}"),
+            type_: DataType::Term("Person".to_string()),
+            dynamic_entity: Some(dynamic_entity),
+        }));
+    }
+
+    for (index, data_id) in data_ids.iter().enumerate() {
+        let mut dynamic_entity = HashMap::with_capacity(5);
+        dynamic_entity.insert(
+            "name".to_string(),
+            EntityValue::EntityString(format!("Measurement file {index:05}")),
+        );
+        dynamic_entity.insert(
+            "encodingFormat".to_string(),
+            EntityValue::EntityString("text/csv".to_string()),
+        );
+        dynamic_entity.insert(
+            "author".to_string(),
+            EntityValue::EntityId(Id::IdArray(
+                (0..authors_per_file)
+                    .map(|offset| format!("#person-{:03}", (index + offset) % author_count))
+                    .collect(),
+            )),
+        );
+        dynamic_entity.insert(
+            "isPartOf".to_string(),
+            EntityValue::EntityId(Id::Id("./".to_string())),
+        );
+        dynamic_entity.insert(
+            "contentSize".to_string(),
+            EntityValue::Entityi64(2_048 + ((index % 97) as i64 * 13)),
+        );
+
+        graph.push(GraphVector::DataEntity(DataEntity {
+            id: data_id.clone(),
+            type_: DataType::TermArray(vec!["File".to_string(), "MediaObject".to_string()]),
+            dynamic_entity: Some(dynamic_entity),
+        }));
+    }
+
+    RoCrate {
+        context: RoCrateContext::ReferenceContext(ROCRATE_CONTEXT_IRI.to_string()),
+        graph,
+    }
+}
+
+fn bench_rocrate_to_rdf(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rdf_export");
+
+    for size in [100usize, 1_000, 4_000] {
+        let input = benchmark_input(size);
+        group.throughput(Throughput::Elements(input.entities as u64));
+        group.bench_with_input(
+            BenchmarkId::new("rocrate_to_rdf", size),
+            &input,
+            |b, input| {
+                b.iter(|| {
+                    rocrate_to_rdf_with_options(
+                        black_box(&input.rocrate),
+                        ContextResolverBuilder::default(),
+                        ConversionOptions::with_base(BASE_IRI),
+                    )
+                    .expect("serialize benchmark iteration")
+                });
+            },
+        );
+
+        group.throughput(Throughput::Elements(input.triples as u64));
+        group.bench_with_input(
+            BenchmarkId::new("rdf_graph_to_turtle", size),
+            &input,
+            |b, input| {
+                b.iter(|| {
+                    black_box(&input.rdf_graph)
+                        .to_string(RdfFormat::Turtle)
+                        .expect("turtle serialization benchmark iteration")
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_rdf_to_rocrate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rdf_import");
+
+    for size in [100usize, 1_000, 4_000] {
+        let input = benchmark_input(size);
+        group.throughput(Throughput::Elements(input.triples as u64));
+        group.bench_with_input(
+            BenchmarkId::new("turtle_to_rocrate", size),
+            &input,
+            |b, input| {
+                b.iter(|| {
+                    rdf_to_rocrate(
+                        black_box(input.turtle.as_str()),
+                        RdfFormat::Turtle,
+                        Some(BASE_IRI),
+                    )
+                    .expect("import benchmark iteration")
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("graph_to_rocrate", size),
+            &input,
+            |b, input| {
+                b.iter(|| {
+                    rdf_graph_to_rocrate(black_box(input.rdf_graph.clone()))
+                        .expect("graph import benchmark iteration")
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(rdf_benches, bench_rocrate_to_rdf, bench_rdf_to_rocrate);
+criterion_main!(rdf_benches);

--- a/src/ro_crate/context.rs
+++ b/src/ro_crate/context.rs
@@ -1,7 +1,7 @@
 use log::debug;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use std::collections::HashMap;
+use thiserror::Error;
 use uuid::Uuid;
 
 use crate::ro_crate::schema::{self, RoCrateSchemaVersion};

--- a/src/ro_crate/convert.rs
+++ b/src/ro_crate/convert.rs
@@ -14,16 +14,16 @@ use crate::ro_crate::graph_vector::GraphVector;
 use crate::ro_crate::rocrate::RoCrate;
 use log::warn;
 use polars::prelude::*;
-use thiserror::Error;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ConvertError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error(transparent)]
-    PolarsError(#[from] polars::error::PolarsError)
+    PolarsError(#[from] polars::error::PolarsError),
 }
 
 pub fn to_df(rocrate: &RoCrate) -> DataFrame {

--- a/src/ro_crate/rdf/convert.rs
+++ b/src/ro_crate/rdf/convert.rs
@@ -59,6 +59,7 @@ struct RdfConverter<'a> {
     xsd_integer: NamedNode,
     xsd_double: NamedNode,
     xsd_boolean: NamedNode,
+    named_node_cache: HashMap<String, NamedNode>,
 }
 
 impl<'a> RdfConverter<'a> {
@@ -70,25 +71,34 @@ impl<'a> RdfConverter<'a> {
             xsd_integer: NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#integer"),
             xsd_double: NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#double"),
             xsd_boolean: NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#boolean"),
+            named_node_cache: HashMap::new(),
         }
     }
 
     /// Expands and validates a term to a NamedNode.
-    fn named_node(&self, term: &str) -> Result<NamedNode, RdfError> {
+    fn named_node(&mut self, term: &str) -> Result<NamedNode, RdfError> {
+        if let Some(node) = self.named_node_cache.get(term) {
+            return Ok(node.clone());
+        }
+
         let expanded = self
             .ctx
             .expand_term_checked(term, self.allow_relative)
             .map_err(|e| RdfError::InvalidIri(e.to_string()))?;
-        if self.allow_relative {
+
+        let node = if self.allow_relative {
             // Skip validation for relative IRIs
-            Ok(NamedNode::new_unchecked(&expanded))
+            NamedNode::new_unchecked(expanded)
         } else {
-            NamedNode::new(&expanded).map_err(|e| RdfError::InvalidIri(e.to_string()))
-        }
+            NamedNode::new(&expanded).map_err(|e| RdfError::InvalidIri(e.to_string()))?
+        };
+
+        self.named_node_cache.insert(term.to_string(), node.clone());
+        Ok(node)
     }
 
     /// Converts an Id to one or more NamedNodes.
-    fn id_to_nodes(&self, id: &Id) -> Result<Vec<NamedNode>, RdfError> {
+    fn id_to_nodes(&mut self, id: &Id) -> Result<Vec<NamedNode>, RdfError> {
         match id {
             Id::Id(s) => Ok(vec![self.named_node(s)?]),
             Id::IdArray(ids) => ids.iter().map(|s| self.named_node(s)).collect(),
@@ -96,7 +106,7 @@ impl<'a> RdfConverter<'a> {
     }
 
     /// Converts an ID string to an RDF Term, handling blank nodes.
-    fn id_string_to_term(&self, id: &str) -> Result<Term, RdfError> {
+    fn id_string_to_term(&mut self, id: &str) -> Result<Term, RdfError> {
         if let Some(local_name) = id.strip_prefix("_:") {
             Ok(Term::BlankNode(BlankNode::new_unchecked(local_name)))
         } else {
@@ -105,7 +115,7 @@ impl<'a> RdfConverter<'a> {
     }
 
     /// Converts an Id to one or more Terms, handling blank nodes.
-    fn id_to_terms(&self, id: &Id) -> Result<Vec<Term>, RdfError> {
+    fn id_to_terms(&mut self, id: &Id) -> Result<Vec<Term>, RdfError> {
         match id {
             Id::Id(single) => Ok(vec![self.id_string_to_term(single)?]),
             Id::IdArray(arr) => arr.iter().map(|s| self.id_string_to_term(s)).collect(),
@@ -118,7 +128,7 @@ impl<'a> RdfConverter<'a> {
     }
 
     /// Converts an entity @id to an RDF subject.
-    fn id_to_subject(&self, id: &str) -> Result<NamedOrBlankNode, RdfError> {
+    fn id_to_subject(&mut self, id: &str) -> Result<NamedOrBlankNode, RdfError> {
         if let Some(local_name) = id.strip_prefix("_:") {
             return Ok(NamedOrBlankNode::BlankNode(BlankNode::new_unchecked(
                 local_name,
@@ -129,8 +139,8 @@ impl<'a> RdfConverter<'a> {
 
     /// Adds type triples for the given DataType.
     fn add_type_triples(
-        &self,
-        triples: &mut Vec<Triple>,
+        &mut self,
+        graph: &mut RdfGraph,
         subject: &NamedOrBlankNode,
         type_: &DataType,
     ) -> Result<(), RdfError> {
@@ -139,7 +149,7 @@ impl<'a> RdfConverter<'a> {
             DataType::TermArray(ts) => ts.iter().map(|s| s.as_str()).collect(),
         };
         for t in types {
-            triples.push(Triple::new(
+            graph.insert(Triple::new(
                 subject.clone(),
                 self.rdf_type.clone(),
                 self.named_node(t)?,
@@ -151,8 +161,8 @@ impl<'a> RdfConverter<'a> {
     /// Adds a string literal triple.
     /// Skips creating the triple if the value is empty, preserving "missing" semantics.
     fn add_string_triple(
-        &self,
-        triples: &mut Vec<Triple>,
+        &mut self,
+        graph: &mut RdfGraph,
         subject: &NamedOrBlankNode,
         predicate: &str,
         value: &str,
@@ -160,7 +170,7 @@ impl<'a> RdfConverter<'a> {
         if value.is_empty() {
             return Ok(());
         }
-        triples.push(Triple::new(
+        graph.insert(Triple::new(
             subject.clone(),
             self.named_node(predicate)?,
             Literal::new_simple_literal(value),
@@ -170,23 +180,23 @@ impl<'a> RdfConverter<'a> {
 
     /// Adds triples for an Id value (single or array).
     fn add_id_triples(
-        &self,
-        triples: &mut Vec<Triple>,
+        &mut self,
+        graph: &mut RdfGraph,
         subject: &NamedOrBlankNode,
         predicate: &str,
         id: &Id,
     ) -> Result<(), RdfError> {
         let pred = self.named_node(predicate)?;
         for node in self.id_to_nodes(id)? {
-            triples.push(Triple::new(subject.clone(), pred.clone(), node));
+            graph.insert(Triple::new(subject.clone(), pred.clone(), node));
         }
         Ok(())
     }
 
     /// Adds a triple for a License value.
     fn add_license_triple(
-        &self,
-        triples: &mut Vec<Triple>,
+        &mut self,
+        graph: &mut RdfGraph,
         subject: &NamedOrBlankNode,
         license: &License,
     ) -> Result<(), RdfError> {
@@ -194,11 +204,11 @@ impl<'a> RdfConverter<'a> {
         match license {
             License::Id(id) => {
                 for node in self.id_to_nodes(id)? {
-                    triples.push(Triple::new(subject.clone(), pred.clone(), node));
+                    graph.insert(Triple::new(subject.clone(), pred.clone(), node));
                 }
             }
             License::Description(desc) => {
-                triples.push(Triple::new(
+                graph.insert(Triple::new(
                     subject.clone(),
                     pred,
                     Literal::new_simple_literal(desc),
@@ -210,94 +220,83 @@ impl<'a> RdfConverter<'a> {
 
     /// Adds triples from dynamic_entity HashMap.
     fn add_dynamic_triples(
-        &self,
-        triples: &mut Vec<Triple>,
+        &mut self,
+        graph: &mut RdfGraph,
         subject: &NamedOrBlankNode,
         dynamic: &HashMap<String, EntityValue>,
     ) -> Result<(), RdfError> {
         for (key, value) in dynamic {
             let pred = self.named_node(key)?;
-            for term in self.entity_value_to_terms(value, key)? {
-                triples.push(Triple::new(subject.clone(), pred.clone(), term));
-            }
+            self.add_entity_value_triples(graph, subject, &pred, value, key)?;
         }
         Ok(())
     }
 
-    /// Converts an EntityValue to RDF Term(s).
-    fn entity_value_to_terms(
-        &self,
+    fn collect_entity_value_terms(
+        &mut self,
         value: &EntityValue,
         predicate_name: &str,
-    ) -> Result<Vec<Term>, RdfError> {
+        terms: &mut Vec<Term>,
+    ) -> Result<(), RdfError> {
         match value {
-            // String literals
-            EntityValue::EntityString(s) => Ok(vec![Term::Literal(Literal::new_simple_literal(s))]),
-            EntityValue::EntityVecString(ss) => Ok(ss
-                .iter()
-                .map(|s| Term::Literal(Literal::new_simple_literal(s)))
-                .collect()),
-
-            // Numeric literals
-            EntityValue::Entityi64(n) => Ok(vec![Term::Literal(
-                self.typed_literal(n, &self.xsd_integer),
-            )]),
-            EntityValue::Entityf64(n) => {
-                Ok(vec![Term::Literal(self.typed_literal(n, &self.xsd_double))])
+            EntityValue::EntityString(s) => {
+                terms.push(Term::Literal(Literal::new_simple_literal(s)));
             }
-            EntityValue::EntityVeci64(ns) => Ok(ns
-                .iter()
-                .map(|n| Term::Literal(self.typed_literal(n, &self.xsd_integer)))
-                .collect()),
-            EntityValue::EntityVecf64(ns) => Ok(ns
-                .iter()
-                .map(|n| Term::Literal(self.typed_literal(n, &self.xsd_double)))
-                .collect()),
-
-            // Boolean
-            EntityValue::EntityBool(b) => Ok(vec![Term::Literal(
-                self.typed_literal(b, &self.xsd_boolean),
-            )]),
-
-            // References (Id, License, DataType)
-            EntityValue::EntityId(id) => self.id_to_terms(id),
+            EntityValue::EntityVecString(ss) => {
+                terms.extend(
+                    ss.iter()
+                        .map(|value| Term::Literal(Literal::new_simple_literal(value))),
+                );
+            }
+            EntityValue::Entityi64(n) => {
+                terms.push(Term::Literal(self.typed_literal(n, &self.xsd_integer)));
+            }
+            EntityValue::Entityf64(n) => {
+                terms.push(Term::Literal(self.typed_literal(n, &self.xsd_double)));
+            }
+            EntityValue::EntityVeci64(ns) => {
+                terms.extend(
+                    ns.iter()
+                        .map(|value| Term::Literal(self.typed_literal(value, &self.xsd_integer))),
+                );
+            }
+            EntityValue::EntityVecf64(ns) => {
+                terms.extend(
+                    ns.iter()
+                        .map(|value| Term::Literal(self.typed_literal(value, &self.xsd_double))),
+                );
+            }
+            EntityValue::EntityBool(b) => {
+                terms.push(Term::Literal(self.typed_literal(b, &self.xsd_boolean)));
+            }
+            EntityValue::EntityId(id) => terms.extend(self.id_to_terms(id)?),
             EntityValue::EntityLicense(license) => match license {
-                License::Id(id) => Ok(self
-                    .id_to_nodes(id)?
-                    .into_iter()
-                    .map(Term::NamedNode)
-                    .collect()),
+                License::Id(id) => {
+                    terms.extend(self.id_to_nodes(id)?.into_iter().map(Term::NamedNode));
+                }
                 License::Description(desc) => {
-                    Ok(vec![Term::Literal(Literal::new_simple_literal(desc))])
+                    terms.push(Term::Literal(Literal::new_simple_literal(desc)));
                 }
             },
             EntityValue::EntityDataType(dt) => {
-                let terms: Vec<&str> = match dt {
+                let types: Vec<&str> = match dt {
                     DataType::Term(t) => vec![t.as_str()],
-                    DataType::TermArray(ts) => ts.iter().map(|s| s.as_str()).collect(),
+                    DataType::TermArray(ts) => ts.iter().map(|value| value.as_str()).collect(),
                 };
-                terms
-                    .into_iter()
-                    .map(|t| Ok(Term::NamedNode(self.named_node(t)?)))
-                    .collect()
-            }
-
-            // Nested values
-            EntityValue::EntityVec(values) => {
-                let mut terms = Vec::new();
-                for v in values {
-                    terms.extend(self.entity_value_to_terms(v, predicate_name)?);
+                for type_name in types {
+                    terms.push(Term::NamedNode(self.named_node(type_name)?));
                 }
-                Ok(terms)
             }
-
-            // Skipped values (log and return empty)
+            EntityValue::EntityVec(values) => {
+                for nested in values {
+                    self.collect_entity_value_terms(nested, predicate_name, terms)?;
+                }
+            }
             EntityValue::EntityObject(obj) => {
                 warn!(
                     "Skipping nested object for predicate '{}': {:?} (would require blank node)",
                     predicate_name, obj
                 );
-                Ok(vec![])
             }
             EntityValue::EntityVecObject(objs) => {
                 warn!(
@@ -305,68 +304,195 @@ impl<'a> RdfConverter<'a> {
                     objs.len(),
                     predicate_name
                 );
-                Ok(vec![])
             }
             EntityValue::NestedDynamicEntity(nested) => {
                 warn!(
                     "Skipping nested dynamic entity for predicate '{}': {:?}",
                     predicate_name, nested
                 );
-                Ok(vec![])
             }
             EntityValue::EntityNull(_) => {
                 warn!("Skipping null value for predicate '{}'", predicate_name);
-                Ok(vec![])
             }
-            EntityValue::EntityNone(_) => Ok(vec![]),
+            EntityValue::EntityNone(_) => {}
             EntityValue::Fallback(val) => {
                 warn!(
                     "Skipping fallback value for predicate '{}': {:?}",
                     predicate_name, val
                 );
-                Ok(vec![])
             }
         }
+
+        Ok(())
+    }
+
+    /// Converts an EntityValue to RDF Term(s).
+    fn entity_value_to_terms(
+        &mut self,
+        value: &EntityValue,
+        predicate_name: &str,
+    ) -> Result<Vec<Term>, RdfError> {
+        let mut terms = Vec::new();
+        self.collect_entity_value_terms(value, predicate_name, &mut terms)?;
+        Ok(terms)
+    }
+
+    fn add_entity_value_triples(
+        &mut self,
+        graph: &mut RdfGraph,
+        subject: &NamedOrBlankNode,
+        predicate: &NamedNode,
+        value: &EntityValue,
+        predicate_name: &str,
+    ) -> Result<(), RdfError> {
+        match value {
+            EntityValue::EntityVec(values) => {
+                for nested in values {
+                    self.add_entity_value_triples(
+                        graph,
+                        subject,
+                        predicate,
+                        nested,
+                        predicate_name,
+                    )?;
+                }
+            }
+            _ => {
+                for term in self.entity_value_to_terms(value, predicate_name)? {
+                    graph.insert(Triple::new(subject.clone(), predicate.clone(), term));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Converts a single entity to RDF triples.
-    fn entity_to_triples(&self, entity: &GraphVector) -> Result<Vec<Triple>, RdfError> {
-        let mut triples = Vec::new();
+    fn add_entity_to_graph(
+        &mut self,
+        entity: &GraphVector,
+        graph: &mut RdfGraph,
+    ) -> Result<(), RdfError> {
         let subject = self.id_to_subject(entity.get_id())?;
 
-        self.add_type_triples(&mut triples, &subject, entity.get_type())?;
+        self.add_type_triples(graph, &subject, entity.get_type())?;
 
         match entity {
             GraphVector::MetadataDescriptor(d) => {
-                self.add_id_triples(&mut triples, &subject, "conformsTo", &d.conforms_to)?;
-                self.add_id_triples(&mut triples, &subject, "about", &d.about)?;
+                self.add_id_triples(graph, &subject, "conformsTo", &d.conforms_to)?;
+                self.add_id_triples(graph, &subject, "about", &d.about)?;
                 if let Some(dyn_ent) = &d.dynamic_entity {
-                    self.add_dynamic_triples(&mut triples, &subject, dyn_ent)?;
+                    self.add_dynamic_triples(graph, &subject, dyn_ent)?;
                 }
             }
             GraphVector::RootDataEntity(r) => {
-                self.add_string_triple(&mut triples, &subject, "name", &r.name)?;
-                self.add_string_triple(&mut triples, &subject, "description", &r.description)?;
-                self.add_string_triple(&mut triples, &subject, "datePublished", &r.date_published)?;
-                self.add_license_triple(&mut triples, &subject, &r.license)?;
+                self.add_string_triple(graph, &subject, "name", &r.name)?;
+                self.add_string_triple(graph, &subject, "description", &r.description)?;
+                self.add_string_triple(graph, &subject, "datePublished", &r.date_published)?;
+                self.add_license_triple(graph, &subject, &r.license)?;
                 if let Some(dyn_ent) = &r.dynamic_entity {
-                    self.add_dynamic_triples(&mut triples, &subject, dyn_ent)?;
+                    self.add_dynamic_triples(graph, &subject, dyn_ent)?;
                 }
             }
             GraphVector::DataEntity(d) => {
                 if let Some(dyn_ent) = &d.dynamic_entity {
-                    self.add_dynamic_triples(&mut triples, &subject, dyn_ent)?;
+                    self.add_dynamic_triples(graph, &subject, dyn_ent)?;
                 }
             }
             GraphVector::ContextualEntity(c) => {
                 if let Some(dyn_ent) = &c.dynamic_entity {
-                    self.add_dynamic_triples(&mut triples, &subject, dyn_ent)?;
+                    self.add_dynamic_triples(graph, &subject, dyn_ent)?;
                 }
             }
         }
 
-        Ok(triples)
+        Ok(())
     }
+}
+
+fn estimate_id_triples(id: &Id) -> usize {
+    match id {
+        Id::Id(_) => 1,
+        Id::IdArray(values) => values.len(),
+    }
+}
+
+fn estimate_license_triples(license: &License) -> usize {
+    match license {
+        License::Id(id) => estimate_id_triples(id),
+        License::Description(_) => 1,
+    }
+}
+
+fn estimate_entity_value_terms(value: &EntityValue) -> usize {
+    match value {
+        EntityValue::EntityString(_)
+        | EntityValue::Entityi64(_)
+        | EntityValue::Entityf64(_)
+        | EntityValue::EntityBool(_)
+        | EntityValue::EntityLicense(License::Description(_)) => 1,
+        EntityValue::EntityVecString(values) => values.len(),
+        EntityValue::EntityId(id) => estimate_id_triples(id),
+        EntityValue::EntityVeci64(values) => values.len(),
+        EntityValue::EntityVecf64(values) => values.len(),
+        EntityValue::EntityLicense(License::Id(id)) => estimate_id_triples(id),
+        EntityValue::EntityDataType(data_type) => match data_type {
+            DataType::Term(_) => 1,
+            DataType::TermArray(values) => values.len(),
+        },
+        EntityValue::EntityVec(values) => values.iter().map(estimate_entity_value_terms).sum(),
+        EntityValue::EntityObject(_)
+        | EntityValue::EntityVecObject(_)
+        | EntityValue::NestedDynamicEntity(_)
+        | EntityValue::EntityNull(_)
+        | EntityValue::EntityNone(_)
+        | EntityValue::Fallback(_) => 0,
+    }
+}
+
+fn estimate_dynamic_triples(dynamic: &HashMap<String, EntityValue>) -> usize {
+    dynamic.values().map(estimate_entity_value_terms).sum()
+}
+
+fn estimate_entity_triples(entity: &GraphVector) -> usize {
+    let type_count = match entity.get_type() {
+        DataType::Term(_) => 1,
+        DataType::TermArray(types) => types.len(),
+    };
+
+    let fixed_count = match entity {
+        GraphVector::MetadataDescriptor(d) => {
+            estimate_id_triples(&d.conforms_to) + estimate_id_triples(&d.about)
+        }
+        GraphVector::RootDataEntity(r) => {
+            usize::from(!r.name.is_empty())
+                + usize::from(!r.description.is_empty())
+                + usize::from(!r.date_published.is_empty())
+                + estimate_license_triples(&r.license)
+        }
+        GraphVector::DataEntity(_) | GraphVector::ContextualEntity(_) => 0,
+    };
+
+    let dynamic_count = match entity {
+        GraphVector::MetadataDescriptor(d) => d
+            .dynamic_entity
+            .as_ref()
+            .map_or(0, estimate_dynamic_triples),
+        GraphVector::RootDataEntity(r) => r
+            .dynamic_entity
+            .as_ref()
+            .map_or(0, estimate_dynamic_triples),
+        GraphVector::DataEntity(d) => d
+            .dynamic_entity
+            .as_ref()
+            .map_or(0, estimate_dynamic_triples),
+        GraphVector::ContextualEntity(c) => c
+            .dynamic_entity
+            .as_ref()
+            .map_or(0, estimate_dynamic_triples),
+    };
+
+    type_count + fixed_count + dynamic_count
 }
 
 /// Converts an RoCrate to RDF triples.
@@ -393,19 +519,12 @@ pub fn rocrate_to_rdf_with_options(
         }
     }
 
-    let converter = RdfConverter::new(&context, &options);
-    let triples: Vec<Triple> = crate_
-        .graph
-        .iter()
-        .map(|entity| converter.entity_to_triples(entity))
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .flatten()
-        .collect();
+    let estimated_triples = crate_.graph.iter().map(estimate_entity_triples).sum();
+    let mut converter = RdfConverter::new(&context, &options);
+    let mut graph = RdfGraph::with_capacity(context.clone(), estimated_triples);
 
-    let mut graph = RdfGraph::new(context);
-    for triple in triples {
-        graph.insert(triple);
+    for entity in &crate_.graph {
+        converter.add_entity_to_graph(entity, &mut graph)?;
     }
 
     Ok(graph)
@@ -499,7 +618,7 @@ mod tests {
     fn test_id_to_subject_accepts_blank_nodes() {
         let ctx = test_context_with_base();
         let options = ConversionOptions::default();
-        let converter = RdfConverter::new(&ctx, &options);
+        let mut converter = RdfConverter::new(&ctx, &options);
 
         let result = converter.id_to_subject("_:Geometry-1");
         assert!(result.is_ok());
@@ -549,7 +668,7 @@ mod tests {
     fn test_entity_value_blank_node_object() {
         let ctx = test_context_with_base();
         let options = ConversionOptions::default();
-        let converter = RdfConverter::new(&ctx, &options);
+        let mut converter = RdfConverter::new(&ctx, &options);
 
         let value = EntityValue::EntityId(Id::Id("_:Geometry-1".to_string()));
         let terms = converter.entity_value_to_terms(&value, "geo").unwrap();

--- a/src/ro_crate/rdf/graph.rs
+++ b/src/ro_crate/rdf/graph.rs
@@ -9,7 +9,7 @@ use super::context::ResolvedContext;
 /// Result of converting an RoCrate to RDF.
 ///
 /// Contains deduplicated triples and the resolved context used for conversion.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RdfGraph {
     /// The RDF triples. Uses HashSet for automatic deduplication.
     pub triples: HashSet<Triple>,
@@ -20,8 +20,13 @@ pub struct RdfGraph {
 impl RdfGraph {
     /// Creates a new RdfGraph with the given context.
     pub fn new(context: ResolvedContext) -> Self {
+        Self::with_capacity(context, 0)
+    }
+
+    /// Creates a new RdfGraph with capacity for the expected triple count.
+    pub fn with_capacity(context: ResolvedContext, capacity: usize) -> Self {
         Self {
-            triples: HashSet::new(),
+            triples: HashSet::with_capacity(capacity),
             context,
         }
     }

--- a/src/ro_crate/rdf/mod.rs
+++ b/src/ro_crate/rdf/mod.rs
@@ -17,8 +17,8 @@ pub mod resolver;
 
 // Re-exports
 pub use context::ResolvedContext;
-pub use convert::{rocrate_to_rdf, rocrate_to_rdf_with_options, ConversionOptions};
+pub use convert::{ConversionOptions, rocrate_to_rdf, rocrate_to_rdf_with_options};
 pub use error::{ContextError, RdfError};
 pub use graph::RdfGraph;
-pub use rdf_io::{rdf_graph_to_rocrate, rdf_to_rocrate, RdfFormat};
+pub use rdf_io::{RdfFormat, rdf_graph_to_rocrate, rdf_to_rocrate};
 pub use resolver::ContextResolverBuilder;

--- a/src/ro_crate/rdf/rdf_io.rs
+++ b/src/ro_crate/rdf/rdf_io.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 
-use oxrdf::{NamedNode, NamedOrBlankNode, Quad, Term, Triple};
+use oxrdf::{NamedNode, NamedOrBlankNode, Term, Triple};
 use oxrdfio::{RdfFormat as OxRdfFormat, RdfParser, RdfSerializer};
 
 use super::context::ResolvedContext;
@@ -88,22 +88,13 @@ fn parse_rdf(input: &str, format: RdfFormat, base: Option<&str>) -> Result<Vec<T
             .map_err(|e| RdfError::ParseError(format!("Invalid base IRI: {}", e)))?;
     }
 
-    let reader = input.as_bytes();
-    let quads: Result<Vec<Quad>, _> = parser.for_reader(reader).collect();
-
-    let quads = quads.map_err(|e| RdfError::ParseError(format!("Failed to parse RDF: {}", e)))?;
-
-    // Convert Quads to Triples (ignoring graph information)
-    let triples = quads
-        .into_iter()
-        .map(|q| Triple {
-            subject: q.subject,
-            predicate: q.predicate,
-            object: q.object,
+    parser
+        .for_slice(input.as_bytes())
+        .map(|quad| {
+            quad.map(Triple::from)
+                .map_err(|e| RdfError::ParseError(format!("Failed to parse RDF: {}", e)))
         })
-        .collect();
-
-    Ok(triples)
+        .collect()
 }
 
 /// Find the metadata descriptor and root data entity IRIs from RDF triples.
@@ -187,8 +178,24 @@ enum EntityType {
     Contextual,
 }
 
-/// XSD namespace for datatype IRIs.
-const XSD_NS: &str = "http://www.w3.org/2001/XMLSchema#";
+const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#int";
+const XSD_LONG: &str = "http://www.w3.org/2001/XMLSchema#long";
+const XSD_SHORT: &str = "http://www.w3.org/2001/XMLSchema#short";
+const XSD_BYTE: &str = "http://www.w3.org/2001/XMLSchema#byte";
+const XSD_NON_NEGATIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
+const XSD_NON_POSITIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#nonPositiveInteger";
+const XSD_POSITIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#positiveInteger";
+const XSD_NEGATIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#negativeInteger";
+const XSD_UNSIGNED_LONG: &str = "http://www.w3.org/2001/XMLSchema#unsignedLong";
+const XSD_UNSIGNED_INT: &str = "http://www.w3.org/2001/XMLSchema#unsignedInt";
+const XSD_UNSIGNED_SHORT: &str = "http://www.w3.org/2001/XMLSchema#unsignedShort";
+const XSD_UNSIGNED_BYTE: &str = "http://www.w3.org/2001/XMLSchema#unsignedByte";
+const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+const XSD_FLOAT: &str = "http://www.w3.org/2001/XMLSchema#float";
+const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
 
 /// Convert an RDF Term to an EntityValue.
 ///
@@ -205,12 +212,10 @@ fn term_to_entity_value(term: &Term) -> EntityValue {
             // Check datatype FIRST before falling back to lexical heuristics
             match datatype {
                 // xsd:string - always return as string, never parse
-                dt if dt == format!("{}string", XSD_NS) => {
-                    EntityValue::EntityString(value_str.to_string())
-                }
+                XSD_STRING => EntityValue::EntityString(value_str.to_string()),
 
                 // xsd:boolean - handle "true", "false", "1", "0"
-                dt if dt == format!("{}boolean", XSD_NS) => match value_str {
+                XSD_BOOLEAN => match value_str {
                     "true" | "1" => EntityValue::EntityBool(true),
                     "false" | "0" => EntityValue::EntityBool(false),
                     _ => {
@@ -223,48 +228,40 @@ fn term_to_entity_value(term: &Term) -> EntityValue {
                 },
 
                 // xsd:integer and variants (int, long, short, byte, etc.)
-                dt if dt == format!("{}integer", XSD_NS)
-                    || dt == format!("{}int", XSD_NS)
-                    || dt == format!("{}long", XSD_NS)
-                    || dt == format!("{}short", XSD_NS)
-                    || dt == format!("{}byte", XSD_NS)
-                    || dt == format!("{}nonNegativeInteger", XSD_NS)
-                    || dt == format!("{}nonPositiveInteger", XSD_NS)
-                    || dt == format!("{}positiveInteger", XSD_NS)
-                    || dt == format!("{}negativeInteger", XSD_NS)
-                    || dt == format!("{}unsignedLong", XSD_NS)
-                    || dt == format!("{}unsignedInt", XSD_NS)
-                    || dt == format!("{}unsignedShort", XSD_NS)
-                    || dt == format!("{}unsignedByte", XSD_NS) =>
-                {
-                    value_str.parse::<i64>().map_or_else(
-                        |_| {
-                            log::warn!(
-                                "Failed to parse '{}' as integer, returning as string",
-                                value_str
-                            );
-                            EntityValue::EntityString(value_str.to_string())
-                        },
-                        EntityValue::Entityi64,
-                    )
-                }
+                XSD_INTEGER
+                | XSD_INT
+                | XSD_LONG
+                | XSD_SHORT
+                | XSD_BYTE
+                | XSD_NON_NEGATIVE_INTEGER
+                | XSD_NON_POSITIVE_INTEGER
+                | XSD_POSITIVE_INTEGER
+                | XSD_NEGATIVE_INTEGER
+                | XSD_UNSIGNED_LONG
+                | XSD_UNSIGNED_INT
+                | XSD_UNSIGNED_SHORT
+                | XSD_UNSIGNED_BYTE => value_str.parse::<i64>().map_or_else(
+                    |_| {
+                        log::warn!(
+                            "Failed to parse '{}' as integer, returning as string",
+                            value_str
+                        );
+                        EntityValue::EntityString(value_str.to_string())
+                    },
+                    EntityValue::Entityi64,
+                ),
 
                 // xsd:double, xsd:float, xsd:decimal - parse as f64
-                dt if dt == format!("{}double", XSD_NS)
-                    || dt == format!("{}float", XSD_NS)
-                    || dt == format!("{}decimal", XSD_NS) =>
-                {
-                    value_str.parse::<f64>().map_or_else(
-                        |_| {
-                            log::warn!(
-                                "Failed to parse '{}' as float, returning as string",
-                                value_str
-                            );
-                            EntityValue::EntityString(value_str.to_string())
-                        },
-                        EntityValue::Entityf64,
-                    )
-                }
+                XSD_DOUBLE | XSD_FLOAT | XSD_DECIMAL => value_str.parse::<f64>().map_or_else(
+                    |_| {
+                        log::warn!(
+                            "Failed to parse '{}' as float, returning as string",
+                            value_str
+                        );
+                        EntityValue::EntityString(value_str.to_string())
+                    },
+                    EntityValue::Entityf64,
+                ),
 
                 // Unknown datatype or plain literal - fall back to lexical heuristics
                 // Note: Plain literals in RDF 1.1 have implicit xsd:string type,

--- a/src/ro_crate/rdf/rdf_io.rs
+++ b/src/ro_crate/rdf/rdf_io.rs
@@ -3,7 +3,9 @@
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 
-use oxrdf::{NamedNode, NamedOrBlankNode, Term, Triple};
+#[cfg(test)]
+use oxrdf::NamedNode;
+use oxrdf::{NamedOrBlankNode, Term, Triple};
 use oxrdfio::{RdfFormat as OxRdfFormat, RdfParser, RdfSerializer};
 
 use super::context::ResolvedContext;
@@ -18,6 +20,30 @@ use crate::ro_crate::graph_vector::GraphVector;
 use crate::ro_crate::metadata_descriptor::MetadataDescriptor;
 use crate::ro_crate::rocrate::RoCrate;
 use crate::ro_crate::root::RootDataEntity;
+
+const RDF_TYPE_IRI: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const SCHEMA_ABOUT_IRI: &str = "http://schema.org/about";
+const SCHEMA_DATASET_IRI: &str = "http://schema.org/Dataset";
+const ROCRATE_CONTEXT_IRI: &str = "https://w3id.org/ro/crate/1.2/context";
+
+const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#int";
+const XSD_LONG: &str = "http://www.w3.org/2001/XMLSchema#long";
+const XSD_SHORT: &str = "http://www.w3.org/2001/XMLSchema#short";
+const XSD_BYTE: &str = "http://www.w3.org/2001/XMLSchema#byte";
+const XSD_NON_NEGATIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
+const XSD_NON_POSITIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#nonPositiveInteger";
+const XSD_POSITIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#positiveInteger";
+const XSD_NEGATIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#negativeInteger";
+const XSD_UNSIGNED_LONG: &str = "http://www.w3.org/2001/XMLSchema#unsignedLong";
+const XSD_UNSIGNED_INT: &str = "http://www.w3.org/2001/XMLSchema#unsignedInt";
+const XSD_UNSIGNED_SHORT: &str = "http://www.w3.org/2001/XMLSchema#unsignedShort";
+const XSD_UNSIGNED_BYTE: &str = "http://www.w3.org/2001/XMLSchema#unsignedByte";
+const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+const XSD_FLOAT: &str = "http://www.w3.org/2001/XMLSchema#float";
+const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
 
 /// Supported RDF serialization formats for RO-Crate I/O.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,6 +143,7 @@ fn parse_rdf(input: &str, format: RdfFormat, base: Option<&str>) -> Result<Vec<T
 /// # Errors
 ///
 /// Returns `RdfError::MissingRootEntities` if required entities are not found.
+#[cfg(test)]
 fn find_root_entities(triples: &[Triple]) -> Result<(String, String), RdfError> {
     let schema_about = NamedNode::new_unchecked("http://schema.org/about");
     let rdf_type = NamedNode::new_unchecked("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
@@ -178,24 +205,497 @@ enum EntityType {
     Contextual,
 }
 
-const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
-const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
-const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
-const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#int";
-const XSD_LONG: &str = "http://www.w3.org/2001/XMLSchema#long";
-const XSD_SHORT: &str = "http://www.w3.org/2001/XMLSchema#short";
-const XSD_BYTE: &str = "http://www.w3.org/2001/XMLSchema#byte";
-const XSD_NON_NEGATIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
-const XSD_NON_POSITIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#nonPositiveInteger";
-const XSD_POSITIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#positiveInteger";
-const XSD_NEGATIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#negativeInteger";
-const XSD_UNSIGNED_LONG: &str = "http://www.w3.org/2001/XMLSchema#unsignedLong";
-const XSD_UNSIGNED_INT: &str = "http://www.w3.org/2001/XMLSchema#unsignedInt";
-const XSD_UNSIGNED_SHORT: &str = "http://www.w3.org/2001/XMLSchema#unsignedShort";
-const XSD_UNSIGNED_BYTE: &str = "http://www.w3.org/2001/XMLSchema#unsignedByte";
-const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
-const XSD_FLOAT: &str = "http://www.w3.org/2001/XMLSchema#float";
-const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
+#[derive(Debug, Default)]
+struct IndexedEntity {
+    properties: HashMap<String, Vec<EntityValue>>,
+    outgoing_refs: Vec<String>,
+    type_iris: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct IndexedGraph {
+    entities: HashMap<String, IndexedEntity>,
+    metadata_about_candidates: Vec<(String, String)>,
+}
+
+impl IndexedGraph {
+    fn from_triples<I>(triples: I) -> Self
+    where
+        I: IntoIterator<Item = Triple>,
+    {
+        let mut graph = Self::default();
+
+        for triple in triples {
+            let subject = subject_to_string(&triple.subject);
+            let predicate = triple.predicate.as_str();
+            let entity = graph.entities.entry(subject.clone()).or_default();
+
+            if predicate == RDF_TYPE_IRI {
+                if let Term::NamedNode(type_node) = &triple.object {
+                    entity.type_iris.push(type_node.as_str().to_string());
+                }
+            } else {
+                entity
+                    .properties
+                    .entry(predicate.to_string())
+                    .or_default()
+                    .push(term_to_entity_value(&triple.object));
+                push_outgoing_ref(&triple.object, &mut entity.outgoing_refs);
+
+                if predicate == SCHEMA_ABOUT_IRI
+                    && subject.contains("ro-crate-metadata.json")
+                    && let Term::NamedNode(object) = &triple.object
+                {
+                    graph
+                        .metadata_about_candidates
+                        .push((subject.clone(), object.as_str().to_string()));
+                }
+            }
+        }
+
+        graph
+    }
+
+    fn find_root_entities(&self) -> Result<(String, String), RdfError> {
+        if self.metadata_about_candidates.is_empty() {
+            return Err(RdfError::MissingRootEntities(
+                "Could not find metadata file with schema:about referencing a crate".to_string(),
+            ));
+        }
+
+        for (metadata_iri, crate_iri) in &self.metadata_about_candidates {
+            if self.entities.get(crate_iri).is_some_and(|entity| {
+                entity
+                    .type_iris
+                    .iter()
+                    .any(|type_iri| type_iri == SCHEMA_DATASET_IRI)
+            }) {
+                return Ok((metadata_iri.clone(), crate_iri.clone()));
+            }
+        }
+
+        Err(RdfError::MissingRootEntities(
+            "Could not find root crate (schema:Dataset) referenced by metadata file".to_string(),
+        ))
+    }
+}
+
+fn subject_to_string(subject: &NamedOrBlankNode) -> String {
+    match subject {
+        NamedOrBlankNode::NamedNode(node) => node.as_str().to_string(),
+        NamedOrBlankNode::BlankNode(node) => format!("_:{}", node.as_str()),
+    }
+}
+
+fn push_outgoing_ref(term: &Term, outgoing_refs: &mut Vec<String>) {
+    match term {
+        Term::NamedNode(node) => outgoing_refs.push(node.as_str().to_string()),
+        Term::BlankNode(node) => outgoing_refs.push(format!("_:{}", node.as_str())),
+        Term::Literal(_) => {}
+    }
+}
+
+fn collapse_values(values: Vec<EntityValue>) -> Option<EntityValue> {
+    match <[EntityValue; 1]>::try_from(values) {
+        Ok([single]) => Some(single),
+        Err(values) if values.is_empty() => None,
+        Err(values) => Some(EntityValue::EntityVec(values)),
+    }
+}
+
+struct ContextCompactor<'a> {
+    context: &'a ResolvedContext,
+    exact_terms: HashMap<&'a str, &'a str>,
+    prefixes: Vec<(&'a str, &'a str)>,
+    cache: HashMap<String, String>,
+}
+
+impl<'a> ContextCompactor<'a> {
+    fn new(context: &'a ResolvedContext) -> Self {
+        let exact_terms = context
+            .terms
+            .iter()
+            .map(|(term, iri)| (iri.as_str(), term.as_str()))
+            .collect();
+
+        let mut prefixes: Vec<_> = context
+            .prefixes
+            .iter()
+            .map(|(prefix, namespace)| (prefix.as_str(), namespace.as_str()))
+            .collect();
+        prefixes.sort_unstable_by(|(_, left), (_, right)| right.len().cmp(&left.len()));
+
+        Self {
+            context,
+            exact_terms,
+            prefixes,
+            cache: HashMap::new(),
+        }
+    }
+
+    fn compact(&mut self, iri: &str) -> String {
+        if let Some(compacted) = self.cache.get(iri) {
+            return compacted.clone();
+        }
+
+        let compacted = if let Some(term) = self.exact_terms.get(iri) {
+            (*term).to_string()
+        } else if let Some((prefix, namespace)) = self
+            .prefixes
+            .iter()
+            .find(|(_, namespace)| iri.starts_with(*namespace))
+        {
+            format!("{}:{}", prefix, &iri[namespace.len()..])
+        } else if let Some(vocab) = &self.context.vocab {
+            if iri.starts_with(vocab) {
+                iri[vocab.len()..].to_string()
+            } else if let Some(base) = &self.context.base {
+                compact_against_base(base, iri)
+            } else {
+                iri.to_string()
+            }
+        } else if let Some(base) = &self.context.base {
+            compact_against_base(base, iri)
+        } else {
+            iri.to_string()
+        };
+
+        self.cache.insert(iri.to_string(), compacted.clone());
+        compacted
+    }
+}
+
+fn compact_against_base(base: &str, iri: &str) -> String {
+    let base_no_slash = base.trim_end_matches('/');
+    if let Some(fragment_part) = iri.strip_prefix(base_no_slash)
+        && fragment_part.starts_with('#')
+    {
+        return fragment_part.to_string();
+    }
+
+    if let Some(relative) = iri.strip_prefix(base) {
+        if relative.is_empty() {
+            return "./".to_string();
+        }
+        return relative.to_string();
+    }
+
+    iri.to_string()
+}
+
+fn compact_types_with_compactor(
+    type_iris: &[String],
+    compactor: &mut ContextCompactor<'_>,
+) -> (DataType, Vec<String>) {
+    let types: Vec<String> = type_iris
+        .iter()
+        .map(|type_iri| compactor.compact(type_iri))
+        .collect();
+
+    let data_type = if types.is_empty() {
+        DataType::Term("Thing".to_string())
+    } else if types.len() == 1 {
+        DataType::Term(types[0].clone())
+    } else {
+        DataType::TermArray(types.clone())
+    };
+
+    (data_type, types)
+}
+
+fn compact_entity_value_with_compactor(
+    value: &mut EntityValue,
+    compactor: &mut ContextCompactor<'_>,
+) {
+    match value {
+        EntityValue::EntityId(id) => match id {
+            Id::Id(iri) => {
+                if !iri.starts_with("_:") {
+                    let compacted = compactor.compact(iri);
+                    if compacted == *iri && iri.starts_with("http") {
+                        log::warn!("No context mapping for IRI '{}', using raw URI", iri);
+                    }
+                    *iri = ensure_relative_prefix(&compacted);
+                }
+            }
+            Id::IdArray(iris_vec) => {
+                for iri in iris_vec.iter_mut() {
+                    if !iri.starts_with("_:") {
+                        let compacted = compactor.compact(iri);
+                        if compacted == *iri && iri.starts_with("http") {
+                            log::warn!("No context mapping for IRI '{}', using raw URI", iri);
+                        }
+                        *iri = ensure_relative_prefix(&compacted);
+                    }
+                }
+            }
+        },
+        EntityValue::EntityVec(vec) => {
+            for nested in vec.iter_mut() {
+                compact_entity_value_with_compactor(nested, compactor);
+            }
+        }
+        EntityValue::EntityObject(map) => {
+            for nested in map.values_mut() {
+                compact_entity_value_with_compactor(nested, compactor);
+            }
+        }
+        EntityValue::EntityVecObject(vec_map) => {
+            for map in vec_map.iter_mut() {
+                for nested in map.values_mut() {
+                    compact_entity_value_with_compactor(nested, compactor);
+                }
+            }
+        }
+        EntityValue::NestedDynamicEntity(nested) => {
+            compact_entity_value_with_compactor(nested, compactor);
+        }
+        _ => {}
+    }
+}
+
+fn build_properties_from_indexed_entity(
+    raw_properties: HashMap<String, Vec<EntityValue>>,
+    compactor: &mut ContextCompactor<'_>,
+) -> HashMap<String, EntityValue> {
+    raw_properties
+        .into_iter()
+        .filter_map(|(key, values)| {
+            let mut value = collapse_values(values)?;
+            compact_entity_value_with_compactor(&mut value, compactor);
+            Some((compactor.compact(&key), value))
+        })
+        .collect()
+}
+
+fn build_metadata_descriptor_from_index(
+    metadata_iri: &str,
+    root_iri: &str,
+    entity: IndexedEntity,
+    compactor: &mut ContextCompactor<'_>,
+) -> MetadataDescriptor {
+    let mut metadata_properties =
+        build_properties_from_indexed_entity(entity.properties, compactor);
+    let (metadata_type, _) = compact_types_with_compactor(&entity.type_iris, compactor);
+
+    let about = metadata_properties
+        .remove("about")
+        .and_then(|value| match value {
+            EntityValue::EntityId(id) => Some(id),
+            _ => None,
+        })
+        .unwrap_or_else(|| Id::Id(root_iri.to_string()));
+
+    let compacted_id = if metadata_iri.contains("ro-crate-metadata.json") {
+        "ro-crate-metadata.json".to_string()
+    } else {
+        compactor.compact(metadata_iri)
+    };
+
+    MetadataDescriptor {
+        id: compacted_id,
+        type_: metadata_type,
+        conforms_to: Id::Id(ROCRATE_CONTEXT_IRI.to_string()),
+        about,
+        dynamic_entity: Some(metadata_properties),
+    }
+}
+
+fn build_root_entity_from_index(
+    root_iri: &str,
+    entity: IndexedEntity,
+    compactor: &mut ContextCompactor<'_>,
+) -> RootDataEntity {
+    let mut root_properties = build_properties_from_indexed_entity(entity.properties, compactor);
+    let (root_type, _) = compact_types_with_compactor(&entity.type_iris, compactor);
+
+    let name = root_properties
+        .remove("name")
+        .and_then(|value| match value {
+            EntityValue::EntityString(name) => Some(name),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            log::warn!(
+                "Root entity '{}' missing 'name' property (SHOULD per RO-Crate spec)",
+                root_iri
+            );
+            String::new()
+        });
+
+    let description = root_properties
+        .remove("description")
+        .and_then(|value| match value {
+            EntityValue::EntityString(description) => Some(description),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            log::warn!(
+                "Root entity '{}' missing 'description' property (SHOULD per RO-Crate spec)",
+                root_iri
+            );
+            String::new()
+        });
+
+    let date_published = root_properties
+        .remove("datePublished")
+        .and_then(|value| match value {
+            EntityValue::EntityString(date_published) => Some(date_published),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            log::warn!(
+                "Root entity '{}' missing 'datePublished' property (SHOULD per RO-Crate spec)",
+                root_iri
+            );
+            String::new()
+        });
+
+    let license = root_properties
+        .remove("license")
+        .map(|value| match value {
+            EntityValue::EntityId(id) => License::Id(id),
+            EntityValue::EntityString(description) => License::Description(description),
+            _ => License::Description(String::new()),
+        })
+        .unwrap_or_else(|| {
+            log::warn!(
+                "Root entity '{}' missing 'license' property (SHOULD per RO-Crate spec)",
+                root_iri
+            );
+            License::Description(String::new())
+        });
+
+    RootDataEntity {
+        id: ensure_relative_prefix(&compactor.compact(root_iri)),
+        type_: root_type,
+        name,
+        description,
+        date_published,
+        license,
+        dynamic_entity: Some(root_properties),
+    }
+}
+
+fn build_graph_entity_from_index(
+    iri: &str,
+    entity: IndexedEntity,
+    compactor: &mut ContextCompactor<'_>,
+) -> GraphVector {
+    let properties = build_properties_from_indexed_entity(entity.properties, compactor);
+    let (entity_type, type_strings) = compact_types_with_compactor(&entity.type_iris, compactor);
+    let compacted_id = ensure_relative_prefix(&compactor.compact(iri));
+
+    match classify_entity(&compacted_id, &type_strings) {
+        EntityType::Data => GraphVector::DataEntity(DataEntity {
+            id: compacted_id,
+            type_: entity_type,
+            dynamic_entity: Some(properties),
+        }),
+        EntityType::Contextual => GraphVector::ContextualEntity(ContextualEntity {
+            id: compacted_id,
+            type_: entity_type,
+            dynamic_entity: Some(properties),
+        }),
+    }
+}
+
+fn collect_reachable_entities_indexed(
+    root_iri: &str,
+    graph: &IndexedGraph,
+    context: &ResolvedContext,
+) -> HashSet<String> {
+    let mut reachable = HashSet::new();
+    let mut to_process = vec![root_iri.to_string()];
+
+    while let Some(current_iri) = to_process.pop() {
+        if !reachable.insert(current_iri.clone()) {
+            continue;
+        }
+
+        let Some(entity) = graph.entities.get(&current_iri) else {
+            continue;
+        };
+
+        for iri in &entity.outgoing_refs {
+            if reachable.contains(iri) || is_vocabulary_iri(iri, context) {
+                continue;
+            }
+
+            if graph.entities.contains_key(iri) {
+                to_process.push(iri.clone());
+            } else {
+                log::warn!(
+                    "Dangling reference '{}': referenced but not defined in the graph. \
+                     Consider adding a contextual entity for this reference.",
+                    iri
+                );
+            }
+        }
+    }
+
+    reachable
+}
+
+fn rdf_index_to_rocrate_with_context(
+    mut graph_index: IndexedGraph,
+    context: ResolvedContext,
+) -> Result<RoCrate, RdfError> {
+    let (metadata_iri, root_iri) = graph_index.find_root_entities()?;
+    let reachable_iris = collect_reachable_entities_indexed(&root_iri, &graph_index, &context);
+
+    for iri in graph_index.entities.keys() {
+        if iri != &metadata_iri && iri != &root_iri && !reachable_iris.contains(iri) {
+            log::warn!(
+                "Entity '{}' is not reachable from root and will be excluded",
+                iri
+            );
+        }
+    }
+
+    let mut compactor = ContextCompactor::new(&context);
+    let metadata_descriptor = build_metadata_descriptor_from_index(
+        &metadata_iri,
+        &root_iri,
+        graph_index.entities.remove(&metadata_iri).ok_or_else(|| {
+            RdfError::MissingRootEntities(format!(
+                "Metadata entity '{}' disappeared during indexing",
+                metadata_iri
+            ))
+        })?,
+        &mut compactor,
+    );
+    let root_entity = build_root_entity_from_index(
+        &root_iri,
+        graph_index.entities.remove(&root_iri).ok_or_else(|| {
+            RdfError::MissingRootEntities(format!(
+                "Root entity '{}' disappeared during indexing",
+                root_iri
+            ))
+        })?,
+        &mut compactor,
+    );
+
+    let mut graph = vec![
+        GraphVector::MetadataDescriptor(metadata_descriptor),
+        GraphVector::RootDataEntity(root_entity),
+    ];
+
+    for iri in reachable_iris {
+        if iri == metadata_iri || iri == root_iri {
+            continue;
+        }
+
+        if let Some(entity) = graph_index.entities.remove(&iri) {
+            graph.push(build_graph_entity_from_index(&iri, entity, &mut compactor));
+        }
+    }
+
+    Ok(RoCrate {
+        context: RoCrateContext::ReferenceContext(ROCRATE_CONTEXT_IRI.to_string()),
+        graph,
+    })
+}
 
 /// Convert an RDF Term to an EntityValue.
 ///
@@ -301,6 +801,7 @@ fn parse_literal_heuristically(value_str: &str) -> EntityValue {
 ///
 /// This is used internally for graph traversal where property names don't matter.
 /// For final entity building, use `extract_entity_properties_with_context` instead.
+#[cfg(test)]
 fn extract_entity_properties_simple(
     subject_iri: &str,
     triples: &[Triple],
@@ -342,6 +843,7 @@ fn extract_entity_properties_simple(
 ///
 /// Uses an explicit stack to avoid recursion. Includes vocabulary IRIs and
 /// blank nodes; callers can filter to entity subjects as needed.
+#[cfg(test)]
 fn extract_iris_from_entity_value(value: &EntityValue, iris: &mut HashSet<String>) {
     let mut stack: Vec<&EntityValue> = vec![value];
 
@@ -406,6 +908,7 @@ fn is_vocabulary_iri(iri: &str, context: &ResolvedContext) -> bool {
 /// pointing to an external resource not defined in this RO-Crate.
 ///
 /// Handles both named nodes and blank nodes (with `_:` prefix).
+#[cfg(test)]
 fn is_entity_subject(iri: &str, triples: &[Triple]) -> bool {
     triples.iter().any(|t| {
         let subject_str = match &t.subject {
@@ -436,6 +939,7 @@ fn is_entity_subject(iri: &str, triples: &[Triple]) -> bool {
 /// # Returns
 ///
 /// A HashSet of all reachable entity IRIs that exist in the graph
+#[cfg(test)]
 fn collect_reachable_entities(
     root_iri: &str,
     triples: &[Triple],
@@ -575,52 +1079,6 @@ fn infer_base_from_metadata(metadata_iri: &str) -> Option<String> {
     None
 }
 
-/// Helper function to extract types from triples for a given IRI.
-///
-/// Returns a tuple of (DataType, Vec<String>) where the Vec contains raw type strings
-/// needed for entity classification.
-fn extract_types(
-    iri: &str,
-    triples: &[Triple],
-    context: &ResolvedContext,
-) -> (DataType, Vec<String>) {
-    let rdf_type = NamedNode::new_unchecked("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
-    let mut types = Vec::new();
-
-    for triple in triples {
-        let subject_str = match &triple.subject {
-            NamedOrBlankNode::NamedNode(n) => n.as_str().to_string(),
-            NamedOrBlankNode::BlankNode(n) => format!("_:{}", n.as_str()),
-        };
-        if subject_str == iri && triple.predicate == rdf_type {
-            if let Term::NamedNode(type_node) = &triple.object {
-                let compacted_type = context.compact_iri(type_node.as_str());
-                types.push(compacted_type);
-            }
-        }
-    }
-
-    let data_type = if types.is_empty() {
-        DataType::Term("Thing".to_string())
-    } else if types.len() == 1 {
-        DataType::Term(types[0].clone())
-    } else {
-        DataType::TermArray(types.clone())
-    };
-
-    (data_type, types)
-}
-
-/// Helper function to compact entity properties using ResolvedContext.
-fn compact_entity_properties(
-    properties: &mut HashMap<String, EntityValue>,
-    context: &ResolvedContext,
-) {
-    for value in properties.values_mut() {
-        compact_entity_value_with_context(value, context);
-    }
-}
-
 /// Helper function to add "./" prefix to relative paths (for RO-Crate compliance).
 fn ensure_relative_prefix(iri: &str) -> String {
     // If it's already a relative path or an absolute URI, return as-is
@@ -641,313 +1099,12 @@ fn ensure_relative_prefix(iri: &str) -> String {
     }
 }
 
-/// Helper function to compact an EntityValue recursively using ResolvedContext.
-fn compact_entity_value_with_context(value: &mut EntityValue, context: &ResolvedContext) {
-    match value {
-        EntityValue::EntityId(id) => {
-            match id {
-                Id::Id(iri) => {
-                    // Skip blank nodes
-                    if !iri.starts_with("_:") {
-                        let compacted = context.compact_iri(iri);
-                        // Log if compaction didn't work for an HTTP IRI
-                        if compacted == *iri && iri.starts_with("http") {
-                            log::warn!("No context mapping for IRI '{}', using raw URI", iri);
-                        }
-                        // Add "./" prefix for RO-Crate relative paths
-                        *iri = ensure_relative_prefix(&compacted);
-                    }
-                }
-                Id::IdArray(iris_vec) => {
-                    for iri in iris_vec.iter_mut() {
-                        if !iri.starts_with("_:") {
-                            let compacted = context.compact_iri(iri);
-                            // Log if compaction didn't work for an HTTP IRI
-                            if compacted == *iri && iri.starts_with("http") {
-                                log::warn!("No context mapping for IRI '{}', using raw URI", iri);
-                            }
-                            // Add "./" prefix for RO-Crate relative paths
-                            *iri = ensure_relative_prefix(&compacted);
-                        }
-                    }
-                }
-            }
-        }
-        EntityValue::EntityVec(vec) => {
-            for v in vec.iter_mut() {
-                compact_entity_value_with_context(v, context);
-            }
-        }
-        EntityValue::EntityObject(map) => {
-            for v in map.values_mut() {
-                compact_entity_value_with_context(v, context);
-            }
-        }
-        EntityValue::EntityVecObject(vec_map) => {
-            for map in vec_map.iter_mut() {
-                for v in map.values_mut() {
-                    compact_entity_value_with_context(v, context);
-                }
-            }
-        }
-        EntityValue::NestedDynamicEntity(nested) => {
-            compact_entity_value_with_context(nested, context);
-        }
-        _ => {}
-    }
-}
-
-/// Helper function to extract entity properties with compacted predicate names.
-fn extract_entity_properties_with_context(
-    subject_iri: &str,
-    triples: &[Triple],
-    context: &ResolvedContext,
-) -> HashMap<String, EntityValue> {
-    let rdf_type = NamedNode::new_unchecked("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
-    let mut properties: HashMap<String, Vec<EntityValue>> = HashMap::new();
-
-    for triple in triples {
-        let subject_str = match &triple.subject {
-            NamedOrBlankNode::NamedNode(n) => n.as_str().to_string(),
-            NamedOrBlankNode::BlankNode(n) => format!("_:{}", n.as_str()),
-        };
-        if subject_str == subject_iri {
-            // Skip rdf:type as it's handled separately
-            if triple.predicate == rdf_type {
-                continue;
-            }
-
-            // Use context to compact the predicate IRI
-            let property_name = context.compact_iri(triple.predicate.as_str());
-            let value = term_to_entity_value(&triple.object);
-
-            properties.entry(property_name).or_default().push(value);
-        }
-    }
-
-    // Convert Vec<EntityValue> to EntityValue (single or array)
-    properties
-        .into_iter()
-        .filter_map(|(key, values)| match <[EntityValue; 1]>::try_from(values) {
-            Ok([single]) => Some((key, single)),
-            Err(values) if values.is_empty() => None,
-            Err(values) => Some((key, EntityValue::EntityVec(values))),
-        })
-        .collect()
-}
-
-/// Build MetadataDescriptor from triples.
-fn build_metadata_descriptor(
-    metadata_iri: &str,
-    root_iri: &str,
-    triples: &[Triple],
-    context: &ResolvedContext,
-) -> MetadataDescriptor {
-    let mut metadata_properties =
-        extract_entity_properties_with_context(metadata_iri, triples, context);
-    let (metadata_type, _) = extract_types(metadata_iri, triples, context);
-
-    // Remove 'about' from dynamic_entity as it's a required field
-    let about = metadata_properties
-        .remove("about")
-        .and_then(|v| match v {
-            EntityValue::EntityId(id) => Some(id),
-            _ => None,
-        })
-        .unwrap_or_else(|| Id::Id(root_iri.to_string()));
-
-    // Compact the metadata ID
-    let compacted_id = if metadata_iri.contains("ro-crate-metadata.json") {
-        "ro-crate-metadata.json".to_string()
-    } else {
-        context.compact_iri(metadata_iri)
-    };
-
-    // Compact properties
-    compact_entity_properties(&mut metadata_properties, context);
-
-    MetadataDescriptor {
-        id: compacted_id,
-        type_: metadata_type,
-        conforms_to: Id::Id("https://w3id.org/ro/crate/1.2/context".to_string()),
-        about,
-        dynamic_entity: Some(metadata_properties),
-    }
-}
-
-/// Build RootDataEntity from triples.
-fn build_root_entity(
-    root_iri: &str,
-    triples: &[Triple],
-    context: &ResolvedContext,
-) -> RootDataEntity {
-    let mut root_properties = extract_entity_properties_with_context(root_iri, triples, context);
-    let (root_type, _) = extract_types(root_iri, triples, context);
-
-    // Extract SHOULD fields with warnings for missing values
-    let name = root_properties
-        .remove("name")
-        .and_then(|v| match v {
-            EntityValue::EntityString(s) => Some(s),
-            _ => None,
-        })
-        .unwrap_or_else(|| {
-            log::warn!(
-                "Root entity '{}' missing 'name' property (SHOULD per RO-Crate spec)",
-                root_iri
-            );
-            String::new()
-        });
-
-    let description = root_properties
-        .remove("description")
-        .and_then(|v| match v {
-            EntityValue::EntityString(s) => Some(s),
-            _ => None,
-        })
-        .unwrap_or_else(|| {
-            log::warn!(
-                "Root entity '{}' missing 'description' property (SHOULD per RO-Crate spec)",
-                root_iri
-            );
-            String::new()
-        });
-
-    let date_published = root_properties
-        .remove("datePublished")
-        .and_then(|v| match v {
-            EntityValue::EntityString(s) => Some(s),
-            _ => None,
-        })
-        .unwrap_or_else(|| {
-            log::warn!(
-                "Root entity '{}' missing 'datePublished' property (SHOULD per RO-Crate spec)",
-                root_iri
-            );
-            String::new()
-        });
-
-    let license = root_properties
-        .remove("license")
-        .map(|v| match v {
-            EntityValue::EntityId(id) => License::Id(id),
-            EntityValue::EntityString(s) => License::Description(s),
-            _ => License::Description(String::new()),
-        })
-        .unwrap_or_else(|| {
-            log::warn!(
-                "Root entity '{}' missing 'license' property (SHOULD per RO-Crate spec)",
-                root_iri
-            );
-            License::Description(String::new())
-        });
-
-    // Compact root ID
-    let compacted_id = ensure_relative_prefix(&context.compact_iri(root_iri));
-
-    // Compact properties
-    compact_entity_properties(&mut root_properties, context);
-
-    RootDataEntity {
-        id: compacted_id,
-        type_: root_type,
-        name,
-        description,
-        date_published,
-        license,
-        dynamic_entity: Some(root_properties),
-    }
-}
-
-/// Build a DataEntity or ContextualEntity from triples.
-fn build_graph_entity(iri: &str, triples: &[Triple], context: &ResolvedContext) -> GraphVector {
-    let mut properties = extract_entity_properties_with_context(iri, triples, context);
-    let (entity_type, type_strings) = extract_types(iri, triples, context);
-
-    // Compact entity ID
-    let compacted_id = ensure_relative_prefix(&context.compact_iri(iri));
-
-    // Compact properties
-    compact_entity_properties(&mut properties, context);
-
-    // Classify entity based on types and IRI patterns
-    match classify_entity(&compacted_id, &type_strings) {
-        EntityType::Data => GraphVector::DataEntity(DataEntity {
-            id: compacted_id,
-            type_: entity_type,
-            dynamic_entity: Some(properties),
-        }),
-        EntityType::Contextual => GraphVector::ContextualEntity(ContextualEntity {
-            id: compacted_id,
-            type_: entity_type,
-            dynamic_entity: Some(properties),
-        }),
-    }
-}
-
 /// Internal implementation: Convert RDF triples to RoCrate using a ResolvedContext.
-fn rdf_to_rocrate_with_context(
-    triples: Vec<Triple>,
-    context: ResolvedContext,
-) -> Result<RoCrate, RdfError> {
-    // Find root entities
-    let (metadata_iri, root_iri) = find_root_entities(&triples)?;
-
-    // Build metadata descriptor and root entity
-    let metadata_descriptor =
-        build_metadata_descriptor(&metadata_iri, &root_iri, &triples, &context);
-    let root_entity = build_root_entity(&root_iri, &triples, &context);
-
-    // Walk the graph to collect reachable entities
-    let reachable_iris = collect_reachable_entities(&root_iri, &triples, &context);
-
-    // Find all entity IRIs in the graph (exclude metadata and root)
-    // This includes both named nodes and blank nodes
-    let mut all_iris = HashSet::new();
-    for triple in &triples {
-        let subject_iri = match &triple.subject {
-            NamedOrBlankNode::NamedNode(node) => node.as_str().to_string(),
-            NamedOrBlankNode::BlankNode(node) => format!("_:{}", node.as_str()),
-        };
-        if subject_iri != metadata_iri && subject_iri != root_iri {
-            all_iris.insert(subject_iri);
-        }
-    }
-
-    // Warn about unreferenced entities
-    for iri in &all_iris {
-        if !reachable_iris.contains(iri) {
-            log::warn!(
-                "Entity '{}' is not reachable from root and will be excluded",
-                iri
-            );
-        }
-    }
-
-    // Build graph starting with metadata and root
-    let mut graph = vec![
-        GraphVector::MetadataDescriptor(metadata_descriptor),
-        GraphVector::RootDataEntity(root_entity),
-    ];
-
-    // Build entities for each reachable IRI
-    for iri in reachable_iris {
-        // Skip metadata and root as they're already added
-        if iri == metadata_iri || iri == root_iri {
-            continue;
-        }
-
-        graph.push(build_graph_entity(&iri, &triples, &context));
-    }
-
-    // Create RoCrate with RO-Crate 1.2 default context
-    let ro_context =
-        RoCrateContext::ReferenceContext("https://w3id.org/ro/crate/1.2/context".to_string());
-
-    Ok(RoCrate {
-        context: ro_context,
-        graph,
-    })
+fn rdf_to_rocrate_with_context<I>(triples: I, context: ResolvedContext) -> Result<RoCrate, RdfError>
+where
+    I: IntoIterator<Item = Triple>,
+{
+    rdf_index_to_rocrate_with_context(IndexedGraph::from_triples(triples), context)
 }
 
 /// Convert an RdfGraph to a RoCrate structure.
@@ -976,11 +1133,8 @@ fn rdf_to_rocrate_with_context(
 /// let restored_crate = rdf_graph_to_rocrate(rdf_graph)?;
 /// ```
 pub fn rdf_graph_to_rocrate(graph: RdfGraph) -> Result<RoCrate, RdfError> {
-    // Convert HashSet<Triple> to Vec<Triple> for processing
-    let triples: Vec<Triple> = graph.triples.into_iter().collect();
-
     // Use the graph's stored context for compaction
-    rdf_to_rocrate_with_context(triples, graph.context)
+    rdf_to_rocrate_with_context(graph.triples, graph.context)
 }
 
 /// Convert RDF data to a RoCrate structure.
@@ -1011,11 +1165,10 @@ pub fn rdf_to_rocrate(
     format: RdfFormat,
     base: Option<&str>,
 ) -> Result<RoCrate, RdfError> {
-    // Parse RDF into triples
-    let triples = parse_rdf(input, format, base)?;
+    let graph_index = IndexedGraph::from_triples(parse_rdf(input, format, base)?);
 
     // Find root entities to infer base IRI
-    let (metadata_iri, _) = find_root_entities(&triples)?;
+    let (metadata_iri, _) = graph_index.find_root_entities()?;
 
     // Determine the base IRI for context resolution (None if not determinable)
     let base_iri = base
@@ -1023,8 +1176,7 @@ pub fn rdf_to_rocrate(
         .or_else(|| infer_base_from_metadata(&metadata_iri));
 
     // Create a ResolvedContext with RO-Crate 1.2 default context + base IRI
-    let ro_context =
-        RoCrateContext::ReferenceContext("https://w3id.org/ro/crate/1.2/context".to_string());
+    let ro_context = RoCrateContext::ReferenceContext(ROCRATE_CONTEXT_IRI.to_string());
 
     let resolver = ContextResolverBuilder::default();
     let mut context = resolver
@@ -1035,7 +1187,7 @@ pub fn rdf_to_rocrate(
     context.base = base_iri;
 
     // Use the internal implementation with the resolved context
-    rdf_to_rocrate_with_context(triples, context)
+    rdf_index_to_rocrate_with_context(graph_index, context)
 }
 
 #[cfg(test)]
@@ -1729,7 +1881,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_rocrate_to_rdf_to_rocrate() {
-        use crate::ro_crate::rdf::convert::{rocrate_to_rdf_with_options, ConversionOptions};
+        use crate::ro_crate::rdf::convert::{ConversionOptions, rocrate_to_rdf_with_options};
         use crate::ro_crate::rdf::resolver::ContextResolverBuilder;
 
         // Create a minimal RO-Crate
@@ -1813,7 +1965,7 @@ mod tests {
 
     #[test]
     fn test_rdf_graph_to_rocrate_uses_context() {
-        use crate::ro_crate::rdf::convert::{rocrate_to_rdf_with_options, ConversionOptions};
+        use crate::ro_crate::rdf::convert::{ConversionOptions, rocrate_to_rdf_with_options};
         use crate::ro_crate::rdf::rdf_graph_to_rocrate;
         use crate::ro_crate::rdf::resolver::ContextResolverBuilder;
 
@@ -2119,8 +2271,10 @@ mod tests {
             data_entities.contains(&"./subdir/file.txt"),
             "Entity ID 'http://example.org/subdir/file.txt' should compact to './subdir/file.txt'"
         );
-        assert!(data_entities.contains(&"./images/photo.jpg"),
-                "Entity ID 'http://example.org/images/photo.jpg' should compact to './images/photo.jpg'");
+        assert!(
+            data_entities.contains(&"./images/photo.jpg"),
+            "Entity ID 'http://example.org/images/photo.jpg' should compact to './images/photo.jpg'"
+        );
 
         // Also check that references in properties have "./" prefix
         let root = crate_obj.graph.iter().find_map(|g| {
@@ -2558,7 +2712,7 @@ mod tests {
 
     #[test]
     fn test_blank_node_roundtrip() {
-        use crate::ro_crate::rdf::convert::{rocrate_to_rdf_with_options, ConversionOptions};
+        use crate::ro_crate::rdf::convert::{ConversionOptions, rocrate_to_rdf_with_options};
         use crate::ro_crate::rdf::resolver::ContextResolverBuilder;
         use crate::ro_crate::read::read_crate_obj;
         use oxrdf::NamedOrBlankNode;

--- a/src/ro_crate/rdf/resolver.rs
+++ b/src/ro_crate/rdf/resolver.rs
@@ -1,9 +1,10 @@
 //! Context resolution for JSON-LD to RDF conversion.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 use crate::ro_crate::context::{ContextItem, RoCrateContext};
-use crate::ro_crate::schema::{RoCrateSchemaVersion, ROCRATE_SCHEMA_1_1, ROCRATE_SCHEMA_1_2};
+use crate::ro_crate::schema::{ROCRATE_SCHEMA_1_1, ROCRATE_SCHEMA_1_2, RoCrateSchemaVersion};
 
 use super::context::ResolvedContext;
 use super::error::ContextError;
@@ -29,6 +30,24 @@ struct CachedContext {
     terms: HashMap<String, String>,
     prefixes: HashMap<String, String>,
     nested_urls: Vec<String>,
+}
+
+static ROCRATE_1_1_CACHE: OnceLock<CachedContext> = OnceLock::new();
+static ROCRATE_1_2_CACHE: OnceLock<CachedContext> = OnceLock::new();
+
+fn builtin_rocrate_context(version: RoCrateSchemaVersion) -> CachedContext {
+    match version {
+        RoCrateSchemaVersion::V1_1 => ROCRATE_1_1_CACHE
+            .get_or_init(|| {
+                parse_context_json(ROCRATE_SCHEMA_1_1).expect("valid RO-Crate 1.1 context")
+            })
+            .clone(),
+        RoCrateSchemaVersion::V1_2 => ROCRATE_1_2_CACHE
+            .get_or_init(|| {
+                parse_context_json(ROCRATE_SCHEMA_1_2).expect("valid RO-Crate 1.2 context")
+            })
+            .clone(),
+    }
 }
 
 impl Default for ContextResolverBuilder {
@@ -96,12 +115,12 @@ impl ContextResolverBuilder {
             RoCrateSchemaVersion::V1_1 => {
                 self.cache
                     .entry(ROCRATE_1_1_CONTEXT_URL.to_string())
-                    .or_insert_with(|| parse_context_json(ROCRATE_SCHEMA_1_1).unwrap());
+                    .or_insert_with(|| builtin_rocrate_context(RoCrateSchemaVersion::V1_1));
             }
             RoCrateSchemaVersion::V1_2 => {
                 self.cache
                     .entry(ROCRATE_1_2_CONTEXT_URL.to_string())
-                    .or_insert_with(|| parse_context_json(ROCRATE_SCHEMA_1_2).unwrap());
+                    .or_insert_with(|| builtin_rocrate_context(RoCrateSchemaVersion::V1_2));
             }
         }
     }

--- a/src/ro_crate/read.rs
+++ b/src/ro_crate/read.rs
@@ -7,12 +7,12 @@ use log::error;
 use log::info;
 use log::warn;
 use serde_json;
-use thiserror::Error;
 use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use thiserror::Error;
 use zip::ZipArchive;
 
 /// Reads and deserialises an RO-Crate from a specified file path.
@@ -203,7 +203,6 @@ pub enum CrateReadError {
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
 }
-
 
 impl PartialEq for CrateReadError {
     fn eq(&self, other: &Self) -> bool {

--- a/src/ro_crate/schema.rs
+++ b/src/ro_crate/schema.rs
@@ -2,8 +2,8 @@
 
 use crate::ro_crate::constraints::{Id, License};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use std::collections::HashMap;
+use thiserror::Error;
 pub(crate) const ROCRATE_SCHEMA_1_1: &str = include_str!("../resources/ro_crate_1_1.jsonld");
 pub(crate) const ROCRATE_SCHEMA_1_2: &str = include_str!("../resources/ro_crate_1_2.jsonld");
 


### PR DESCRIPTION
In our testing we noticed very bad performance for larger crates with 100.000s of entities. This branch improves RO-Crate RDF performance in both directions by reducing repeated scans, cutting intermediate allocations, and caching built-in RO-Crate contexts. It also adds dedicated Criterion benchmarks to measure RDF import and export behavior on larger synthetic crates.

## Changes

- Reworked RDF export to write triples directly into `RdfGraph` instead of building and flattening intermediate triple vectors.
- Added triple-count estimation and `RdfGraph::with_capacity(...)` so RDF graph storage can be preallocated more efficiently.
- Added a named-node cache inside the RDF converter to avoid repeatedly expanding and constructing the same IRIs during serialization.
- Reworked RDF import around a new indexed graph representation built in a single pass over parsed triples.
- Switched RO-Crate reconstruction to operate from that indexed graph, including root discovery, reachability checks, property compaction, and entity rebuilding.
- Reused built-in RO-Crate 1.1 and 1.2 contexts via `OnceLock` so schema parsing is not repeated for each resolver instance.
- Streamlined RDF parsing by collecting triples directly from the parser iterator.
- Added a new Criterion benchmark suite for RDF export, Turtle serialization, Turtle import, and `RdfGraph` to `RoCrate` conversion at multiple crate sizes.
- Registered the new benchmark target in `Cargo.toml` and included minor formatting and import-order cleanup from `cargo fmt`.

On large RO-Crates this results in a 10-50x import and 50-200x export performance improvements, turns out the naive O(n²) approach of the first implementation does not really scale well with crate sizes.